### PR TITLE
Made changes in line with ticket 64 (fixing data errors)

### DIFF
--- a/_episodes/11_fixing_data_errors.md
+++ b/_episodes/11_fixing_data_errors.md
@@ -13,15 +13,16 @@ keypoints:
 
 # Identifying Errors
 
-During the process of loading data it is possible to uncover errors with previously-loaded datasets. OTN is constantly improving our QA/QC tools, which means we are identifying and correcting more and more historical errors.
-
-Generally, there a few ways Node Managers will identify errors:
+During the process of loading data it is possible to uncover errors with previously-loaded datasets. Generally, there a few ways Node Managers will identify errors:
 - By using the `Verification` cells in the Nodebooks
 - When new QA/QC updates are released for the Nodebooks
 - When a researcher identifies an error explicitly
 - When a researcher submits data that does not match previously-loaded records
 
 In the latter case, full comparison between the records is required, followed by a discussion with the researcher to identify if the previously-loaded records or the new records are correct. Often, the outcome is that the data in the DB needs correction.
+
+In other cases, if the [DB Fix Notebooks](https://ocean-tracking-network.github.io/node-manager-training/10_Database%20fix%20notebooks/index.html) covered in the previous lesson do not cover your issue, then you will have to reach out to OTN's data center with a GitLab ticket.
+
 
 # Scoping the Required Correction
 
@@ -32,37 +33,21 @@ Here is the template for reference:
 ~~~
 # **DB Fix Issue**
 
-__This issue title should include schema name, year of record affected__
-- eg "HFX 2020 receiver lat/long change"
-
-__add DB fix label to issue__
-
 ## Related gitlab issue:
-- eg #1234, [paste link to issue]
+- **[paste link to issue]**
 
-## Schema:
-- eg HFX
+## CSV of information needed for each record that needs fixing (look at `0. Home` notebook for column headers):
+- **[link file here]**
 
-## DB table name:
-- eg HFX.moorings
-
-### information needed for each record that needs fixing (repeat for each catalog number):
-1. unique identifier:
-1. original value:
-1. new value:
-
-- [ ] NAME - label issue `db fix`
-- [ ] NAME - tag OTNDC staff for assistance with request (@diniangela etc)
+## Task list
+- [ ] NAME label issue `DB Fix`
+- [ ] NAME create a CSV of changes 
+- [ ] NAME assign to @diniangela to make the change
+- [ ] Angela make database change
 ~~~
 {: .language-plaintext .example}
 
 
 Once fully scoped, you may assign the Issue to OTN Staff to complete the correction. If it is a simple process, they may provide instructions to the Node Manager to complete. **Do not** attempt to correct the issue yourself without consultation with OTN.
-
-# Database Fix Notebooks
-
-Currently, the OTN Database Team is working on a suite of notebooks for fixing common issues found in the database. These are the tools that the OTN Team will be using to correct the identified errors, if the tool to do so already exists.
-
-These notebooks are beyond the scope of the current training but eventually Data Managers who wish to learn more will be able to take further training. In the meantime, if you see notes in the notebooks such as "Use the DB Fix notebook called XXXX to correct this error", please create a `DB Fix Issue` ticket and pass it off to OTN.
 
 {% include links.md %}


### PR DESCRIPTION
Changed the ticket template (EZ) and also made some changes to the verbiage to reflect that the DB fix notebooks are now a real thing that they'll learn about. I based the link on this branch: https://github.com/ocean-tracking-network/node-manager-training/tree/database_fix_notebooks, so once both branches are merged we should be A-OK and the whole shebang should work fine (though of course we (I) should check the link to make sure). 

Let me know if the changes to the wording are OK. 