### PR TITLE
changed two instances of typo 'and can dispose' to 'you can dispose'

### DIFF
--- a/_episodes/08_Detections.md
+++ b/_episodes/08_Detections.md
@@ -306,7 +306,7 @@ Connection Type:postgresql Host:db.for.your.org Database:your_db_name User:your_
 
 ### Load the events file into the c_events_yyyy table
 
-The second last cell loads the events file into a raw table. It depends on successful verification from the last step. Upon successful loading and can dispose of the engine then move on to the next Nodebook.
+The second last cell loads the events file into a raw table. It depends on successful verification from the last step. Upon successful loading, you can dispose of the engine then move on to the next Nodebook.
 
 The Nodebook will indicate the success of the table-creation with the following message:
 

--- a/_episodes/14_movers_notebooks.md
+++ b/_episodes/14_movers_notebooks.md
@@ -332,7 +332,7 @@ Connection Type:postgresql Host:db.for.your.org Database:your_db_name User:your_
 
 ### Load the events file into the c_events_yyyy table
 
-The second last cell loads the events file into a raw table. It depends on successful verification from the last step. Upon successful loading and can dispose of the engine then move on to the next notebook.
+The second last cell loads the events file into a raw table. It depends on successful verification from the last step. Upon successful loading, you can dispose of the engine then move on to the next notebook.
 
 The notebook will indicate the success of the table-creation with the following message:
 


### PR DESCRIPTION
Ticket 60 included the line item "Typo in "Load events file into c_events_yyyy table": "Upon successful loading and can dispose of the engine..." but should say "Upon successful loading, you can dispose..." (or similar)". That was erroneously put in the deployment metadata ticket when it should have been in the detections metadata ticket. Either way, I've fixed that instance, as well as a second in Movers that must have arisen from copy paste. 